### PR TITLE
Added peer dependency for react

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "build": "browserify swipe.js -t literalify -s Swipe -o demo/index.js"
   },
   "dependencies": {
-    "react": "^0.11.1"
+    "react": ">=0.10.0"
+  },
+  "peerDependencies": {
+    "react": ">=0.10.0"
   }
 }


### PR DESCRIPTION
It is not possible to mix different react versions on one page. Doing so would result in an Invariant Violation. We can tell NPM to use just one react version in a project by defining a peer dependency. It will always use the most current version if possible, but nothing below 0.10.0. 

Tested with react 0.10.0
