### PR TITLE
Add reinit method

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -45,6 +45,12 @@ module.exports = React.createClass({
     delete this.swipe
   },
 
+  reinit: function() {
+    this.swipe.kill()
+    delete this.swipe
+    this.swipe = Swipe(this.getDOMNode(), this.props)
+  },
+
   render: function() {
     var container = React.DOM.div(this.props,
       React.DOM.div({style: styles.wrapper},


### PR DESCRIPTION
`reinit` method could be useful if `props.children` changed. But to use this method you need to pass `ref` to `props` which cause a warning:

> Warning: You are calling cloneWithProps() on a child with a ref. This is dangerous because you're creating a new child which will not be added as a ref to its parent.

Here is a solution proposed #2
