### PR TITLE
Update for React 0.12

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -46,14 +46,14 @@ module.exports = React.createClass({
   },
 
   render: function() {
-    var container = React.DOM.div(this.props,
-      React.DOM.div({style: styles.wrapper},
-        React.Children.map(this.props.children, function(child) {
-          return React.addons.cloneWithProps(child, {style: styles.child})
-        })
-      )
-    )
-
-    return React.addons.cloneWithProps(container, {style: styles.container})
+    return <div {...this.props} style={styles.container}>
+      <div style={styles.wrapper}>
+        {this.props.children.map(function(child) {
+          return React.addons.cloneWithProps(
+            child, {key: child.key, style: styles.child})
+        })}
+      </div>
+    </div>
   }
+
 })


### PR DESCRIPTION
Use JSX for render function, since you can now splat properties. Incidentally, this works around React 0.12's requirement that you use 'elements' instead of calling the component functions, by letting JSX do whatever it wants.

`react-swipe` didn't work with the latest React without these changes. I didn't investigate deeply as to why.
