### PR TITLE
Allow slideToIndex with index 0

### DIFF
--- a/react-swipe.js
+++ b/react-swipe.js
@@ -51,7 +51,7 @@
     },
 
     componentDidUpdate: function () {
-      if (this.props.slideToIndex) {
+      if (this.props.slideToIndex || this.props.slideToIndex === 0) {
           this.swipe.slide(this.props.slideToIndex);
       }
     },


### PR DESCRIPTION
slideToIndex had a small bug where sliding to index 0 didn't go through because it's a falsey value.
