### PR TITLE
shouldComponentUpdate should return a boolean value instead of undefined

### DIFF
--- a/react-swipe.js
+++ b/react-swipe.js
@@ -65,7 +65,7 @@
     shouldComponentUpdate: function (nextProps) {
       return (
         (this.props.slideToIndex !== nextProps.slideToIndex) ||
-        this.props.shouldUpdate && !this.props.shouldUpdate(nextProps)
+        (typeof this.props.shouldUpdate !== 'undefined') && !this.props.shouldUpdate(nextProps)
       );
     },
 


### PR DESCRIPTION
Fixes the following warning:
ReactCompositeComponent.shouldComponentUpdate(): Returned undefined instead of a boolean value. Make sure to return true or false.
