### PR TITLE
Fix broken logic for custom shouldUpdate function

### DIFF
--- a/react-swipe.js
+++ b/react-swipe.js
@@ -65,7 +65,7 @@
     shouldComponentUpdate: function (nextProps) {
       return (
         (this.props.slideToIndex !== nextProps.slideToIndex) ||
-        (typeof this.props.shouldUpdate !== 'undefined') && !this.props.shouldUpdate(nextProps)
+        (typeof this.props.shouldUpdate !== 'undefined') && this.props.shouldUpdate(nextProps)
       );
     },
 


### PR DESCRIPTION
Incorrectly negating the logic for the custom function. Component should update when user custom function returns 'true'.
