### PR TITLE
fix blinks of swipe when back to the page.

### DIFF
--- a/react-swipe.js
+++ b/react-swipe.js
@@ -28,7 +28,8 @@
     child: {
       float: 'left',
       width: '100%',
-      position: 'relative'
+      position: 'relative',
+      transitionProperty: 'transform'
     }
   };
 
@@ -78,7 +79,7 @@
             return React.cloneElement(child, {
               ref: child.props.ref,
               key: child.props.key,
-              style: child.props.style ? objectAssign(child.props.style,styles.child) : styles.child
+              style: child.props.style ? objectAssign(child.props.style, styles.child) : styles.child
             });
           })
         )


### PR DESCRIPTION
When back to the page which contains the swiper. While the swiper restore the index of the slide, the slides will blink because of `transiton-property: all`
