### PR TITLE
passing prev props to custom shouldUpdate function

### DIFF
--- a/react-swipe.js
+++ b/react-swipe.js
@@ -68,7 +68,7 @@
     shouldComponentUpdate: function (nextProps) {
       return (
         (this.props.slideToIndex !== nextProps.slideToIndex) ||
-        (typeof this.props.shouldUpdate !== 'undefined') && this.props.shouldUpdate(nextProps)
+        (typeof this.props.shouldUpdate !== 'undefined') && this.props.shouldUpdate(nextProps, this.props)
       );
     },
 


### PR DESCRIPTION
Hi,

In the current setup, the custom `shouldUpdate` function is passed what is to the `ReactSwipe` instance the `nextProps` in its `shouldComponentUpdate` function. These `nextProps` are what is defined as `this.props` in the element rendering `ReactSwipe`.

The parent component would rather need a reference to the previous props.

``` es6
<ReactSwipe
  shouldUpdate={ nextProps => {
    // nextProps === this.props so we don't really need it here
    // rather it would be nice to be handled a reference to the previous props
  } } 
/>
```

Or am i confused about something ? in the PR i just add the previous props to the`shouldUpdate` function, which shouldn't break any existing code, but maybe it would make more sense to only pass these previous props
