### PR TITLE
Multiple swipers on the same view

### DIFF
--- a/react-swipe.js
+++ b/react-swipe.js
@@ -49,7 +49,8 @@
       callback        : React.PropTypes.func,
       transitionEnd   : React.PropTypes.func,
       containerStyles : React.PropTypes.object,
-      wrapperStyles   : React.PropTypes.object
+      wrapperStyles   : React.PropTypes.object,
+      reinitSwipeOnUpdate : React.PropTypes.bool
     },
 
     componentDidMount: function () {
@@ -57,6 +58,10 @@
     },
 
     componentDidUpdate: function () {
+      if (this.props.reinitSwipeOnUpdate) {
+         this.swipe.kill();
+         this.swipe = Swipe(ReactDOM.findDOMNode(this), objectAssign({}, this.props));
+      }
       if (this.props.slideToIndex || this.props.slideToIndex === 0) {
         this.swipe.slide(this.props.slideToIndex);
       }

--- a/react-swipe.js
+++ b/react-swipe.js
@@ -59,8 +59,8 @@
 
     componentDidUpdate: function () {
       if (this.props.reinitSwipeOnUpdate) {
-         this.swipe.kill();
-         this.swipe = Swipe(ReactDOM.findDOMNode(this), objectAssign({}, this.props));
+        this.swipe.kill();
+        this.swipe = Swipe(ReactDOM.findDOMNode(this), objectAssign({}, this.props));
       }
       if (this.props.slideToIndex || this.props.slideToIndex === 0) {
         this.swipe.slide(this.props.slideToIndex);

--- a/react-swipe.js
+++ b/react-swipe.js
@@ -38,18 +38,18 @@
   var ReactSwipe = React.createClass({
     // https://github.com/thebird/Swipe#config-options
     propTypes: {
-      startSlide      : React.PropTypes.number,
-      slideToIndex    : React.PropTypes.number,
-      shouldUpdate    : React.PropTypes.func,
-      speed           : React.PropTypes.number,
-      auto            : React.PropTypes.number,
-      continuous      : React.PropTypes.bool,
-      disableScroll   : React.PropTypes.bool,
-      stopPropagation : React.PropTypes.bool,
-      callback        : React.PropTypes.func,
-      transitionEnd   : React.PropTypes.func,
-      containerStyles : React.PropTypes.object,
-      wrapperStyles   : React.PropTypes.object,
+      startSlide          : React.PropTypes.number,
+      slideToIndex        : React.PropTypes.number,
+      shouldUpdate        : React.PropTypes.func,
+      speed               : React.PropTypes.number,
+      auto                : React.PropTypes.number,
+      continuous          : React.PropTypes.bool,
+      disableScroll       : React.PropTypes.bool,
+      stopPropagation     : React.PropTypes.bool,
+      callback            : React.PropTypes.func,
+      transitionEnd       : React.PropTypes.func,
+      containerStyles     : React.PropTypes.object,
+      wrapperStyles       : React.PropTypes.object,
       reinitSwipeOnUpdate : React.PropTypes.bool
     },
 


### PR DESCRIPTION
Its not possible now to have multiple swipers in the same container
I cant re render the component and expecting the content to change.
We have a issue where we have a slider that is dependant on an dropdown value.
So when this value changes, the slider content changes.

But since the component is already mounted, there is not an entrance to newing up an new Swiper.

This is my suggetstion, works for us.
