### PR TITLE
Fix issue where swipe children styles get applied outside swipe container

### DIFF
--- a/react-swipe.js
+++ b/react-swipe.js
@@ -84,9 +84,7 @@
         React.createElement('div', {style: objectAssign({}, styles.wrapper, this.props.wrapperStyles)},
           React.Children.map(this.props.children, function (child) {
             return React.cloneElement(child, {
-              ref: child.props.ref,
-              key: child.props.key,
-              style: child.props.style ? objectAssign(child.props.style, styles.child) : styles.child
+              style: styles.child
             });
           })
         )


### PR DESCRIPTION
See the issue on my `gh-pages` branch:
http://tomconroy.github.io/react-swipe/demo/
https://github.com/tomconroy/react-swipe/commit/159c4b6ac9dd0ee432b282d32834ad47a70efd9c

Reading the docs for [`React.cloneElement`](https://facebook.github.io/react/docs/top-level-api.html#react.cloneelement) it appears we don't need to copy any of the child props, `React.cloneElement` does this for us (including `key` and `ref`)
