### PR TITLE
Avoid undefined className

### DIFF
--- a/src/reactSwipe.js
+++ b/src/reactSwipe.js
@@ -43,7 +43,8 @@ class ReactSwipe extends Component {
                 position: 'relative',
                 transitionProperty: 'transform'
             }
-        }
+        },
+        className: ''
     };
 
     componentDidMount() {


### PR DESCRIPTION
To avoid 'react-swipe-container undefined' className when not sending className as props
