### PR TITLE
Merge default child styles with children style props

### DIFF
--- a/src/reactSwipe.js
+++ b/src/reactSwipe.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import Swipe from 'swipe-js-iso';
+import objectAssign from 'object-assign';
 
 class ReactSwipe extends Component {
   static propTypes = {
@@ -85,7 +86,9 @@ class ReactSwipe extends Component {
       <div ref="container" id={id} className={`react-swipe-container ${className}`} style={style.container}>
         <div style={style.wrapper}>
           {React.Children.map(children, (child) => {
-            return React.cloneElement(child, {style: style.child});
+            return React.cloneElement(child, {
+              style: child.props.style ? objectAssign(child.props.style, style.child) : style.child
+            });
           })}
         </div>
       </div>


### PR DESCRIPTION
Right now the style props on child elements of react swipe are ignored. This aims to merge those styles with default styles.