### PR TITLE
Use prop-types instead of React.PropTypes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
   "license": "MIT",
   "dependencies": {
     "object-assign": "^4.1.0",
-    "swipe-js-iso": "^2.0.3"
+    "swipe-js-iso": "^2.0.3",
+    "prop-types": "^15.5.7" 
+  },
+  "peerDependencies": {
+    "react": "^15.5.0" 
   },
   "devDependencies": {
     "ava": "^0.13.0",

--- a/src/reactSwipe.js
+++ b/src/reactSwipe.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Swipe from 'swipe-js-iso';
 import objectAssign from 'object-assign';
 


### PR DESCRIPTION
Use of React.PropTypes is deprecated as of React 15.5.

Updates to package.json dependencies and peerDependencies is as
recommended in https://github.com/reactjs/prop-types.