### PR TITLE
change react to a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0",
-    "react": "^16.0.0",
-    "swipe-js-iso": "^2.0.4",
-    "webpack": "^2.7.0"
+    "swipe-js-iso": "^2.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -45,6 +43,7 @@
     "eslint-loader": "^1.9.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-react": "^7.4.0",
+    "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "uglify-js": "^3.1.3",
     "webpack": "^3.6.0",


### PR DESCRIPTION
This PR moves React to a dev dependency. Webpack is also defined as a dev dependency, so I removed it from the main dependencies list.

thanks for making react-swipe!