### PR TITLE
replace "lodash.isequal" package with smaller one

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "lodash.isequal": "^4.5.0",
+    "fast-deep-equal": "^2.0.1",
     "prop-types": "^15.6.0",
     "swipe-js-iso": "^2.1.5"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Swipe from 'swipe-js-iso';
-import isEqual from 'lodash.isequal';
+import isEqual from 'fast-deep-equal';
 
 class ReactSwipe extends Component {
   static propTypes = {


### PR DESCRIPTION
The size of "lodash.isequal" is too large, so I replace it with [fast-deep-equal](https://www.npmjs.com/package/fast-deep-equal)  (422B under gzipped).

https://bundlephobia.com/result?p=react-swipe@6.0.4

![image](https://user-images.githubusercontent.com/5064777/56333822-432eba00-61c8-11e9-9cbb-4978e33592c1.png)