### PR TITLE
#164 Replace lodash by custom deepEqual to reduce bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "lodash.isequal": "^4.5.0",
     "prop-types": "^15.6.0",
     "swipe-js-iso": "^2.1.5"
   },

--- a/src/deepEqual.js
+++ b/src/deepEqual.js
@@ -1,0 +1,17 @@
+export default function deepEqual(a, b) {
+  if (a === b) return true;
+
+  if (a == null || typeof a != 'object' || b == null || typeof b != 'object')
+    return false;
+
+  let keysA = Object.keys(a),
+    keysB = Object.keys(b);
+
+  if (keysA.length != keysB.length) return false;
+
+  for (let key of keysA) {
+    if (!keysB.includes(key) || !deepEqual(a[key], b[key])) return false;
+  }
+
+  return true;
+}

--- a/src/deepEqual.js
+++ b/src/deepEqual.js
@@ -1,13 +1,23 @@
 export default function deepEqual(a, b) {
-  if (a === b) return true;
+  if (a === b) {
+    return true;
+  }
 
-  if (a == null || typeof a != 'object' || b == null || typeof b != 'object')
+  if (
+    a === null ||
+    typeof a !== 'object' ||
+    b === null ||
+    typeof b !== 'object'
+  ) {
     return false;
+  }
 
   let keysA = Object.keys(a),
     keysB = Object.keys(b);
 
-  if (keysA.length != keysB.length) return false;
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
 
   for (let key of keysA) {
     if (!keysB.includes(key) || !deepEqual(a[key], b[key])) return false;

--- a/src/deepEqual.js
+++ b/src/deepEqual.js
@@ -20,7 +20,9 @@ export default function deepEqual(a, b) {
   }
 
   for (let key of keysA) {
-    if (!keysB.includes(key) || !deepEqual(a[key], b[key])) return false;
+    if (!keysB.includes(key) || !deepEqual(a[key], b[key])) {
+      return false;
+    }
   }
 
   return true;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Swipe from 'swipe-js-iso';
-import isEqual from 'lodash.isequal';
+import deepEqual from './deepEqual';
 
 class ReactSwipe extends Component {
   static propTypes = {
@@ -57,7 +57,7 @@ class ReactSwipe extends Component {
     const { childCount, swipeOptions } = this.props;
     const shouldUpdateSwipeInstance =
       prevProps.childCount !== childCount ||
-      !isEqual(prevProps.swipeOptions, swipeOptions);
+      !deepEqual(prevProps.swipeOptions, swipeOptions);
 
     if (shouldUpdateSwipeInstance) {
       this.swipe.kill();


### PR DESCRIPTION
Hello,

Like said in issue #164 `lodash.isequal` increase the bundle size significantly (about 50% 😱). In your project, your need about deep equal is limited, a simple one is enough ! See yourself : 

https://bundlephobia.com/result?p=react-swipe@6.0.4

So, this PR is for replacing the `isequal` with something simpler and custom ! I took the deepEqual code from this thread : 
https://stackoverflow.com/questions/51622641/deep-comparision-how-does-this-code-return-false-when-values-of-2-objects-are-n

By advance, thanks for your review 😌

PS: i didn't commit the `package-lock.json` because our npm versions are different and the diff was huge. So i prefer let you update it to avoid any conflicts ! 